### PR TITLE
Update column size

### DIFF
--- a/init/2-create_tables.sql
+++ b/init/2-create_tables.sql
@@ -15,7 +15,7 @@ DROP TABLE IF EXISTS `trophies`;
 CREATE TABLE `trophies` (
   `id` INT unsigned NOT NULL AUTO_INCREMENT,
   `title` VARCHAR(13) NOT NULL,
-  `description` VARCHAR(1024), -- TODO: サイズは仮
+  `description` VARCHAR(280),
   `user_id` INT unsigned NOT NULL,
   `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,


### PR DESCRIPTION
fix #1

* users
  * name: 50
  * email: 256
* trophies
  * title: 13
  * description: 280

## Ref
* https://help.twitter.com/en/managing-your-account/change-twitter-handle

> Your display name can be up to 50 characters long. 

* [RFC 5321 - Simple Mail Transfer Protocol](https://tools.ietf.org/html/rfc5321)

> The maximum total length of a reverse-path or forward-path is 256
   octets (including the punctuation and element separators).

* [Yahoo!ニュース トピックス「13文字見出し」の極意　難関「コートジボワール」はどう表現？](https://news.yahoo.co.jp/newshack/inside/yahoonews_topics_heading.html)